### PR TITLE
feat: Implement upload handler and paste service

### DIFF
--- a/handlers/retrieval/handler.go
+++ b/handlers/retrieval/handler.go
@@ -1,0 +1,206 @@
+package retrieval
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/johnwmail/nclip/config"
+	"github.com/johnwmail/nclip/internal/services"
+	"github.com/johnwmail/nclip/storage"
+	"github.com/johnwmail/nclip/utils"
+)
+
+// Handler handles paste retrieval operations
+type Handler struct {
+	service *services.PasteService
+	store   storage.PasteStore
+	config  *config.Config
+}
+
+// NewHandler creates a new retrieval handler
+func NewHandler(service *services.PasteService, store storage.PasteStore, config *config.Config) *Handler {
+	return &Handler{
+		service: service,
+		store:   store,
+		config:  config,
+	}
+}
+
+// isHTTPS detects if the request is over HTTPS
+func (h *Handler) isHTTPS(c *gin.Context) bool {
+	// Check X-Forwarded-Proto header (common with load balancers/proxies)
+	if c.GetHeader("X-Forwarded-Proto") == "https" {
+		return true
+	}
+
+	// AWS Lambda Function URLs may use different headers
+	if c.GetHeader("CloudFront-Forwarded-Proto") == "https" {
+		return true
+	}
+
+	// Check if the original URL scheme can be detected from request URL
+	if strings.HasPrefix(c.Request.Header.Get("Referer"), "https://") {
+		return true
+	}
+
+	return false
+}
+
+// isCli detects if the request is from CLI (curl, wget, Invoke-WebRequest, Invoke-RestMethod, etc.)
+func (h *Handler) isCli(c *gin.Context) bool {
+	userAgent := strings.ToLower(c.Request.Header.Get("User-Agent"))
+	if strings.Contains(userAgent, "curl") ||
+		strings.Contains(userAgent, "wget") ||
+		strings.Contains(userAgent, "powershell") {
+		return true
+	}
+	return false
+}
+
+// View handles paste viewing via GET /:slug
+func (h *Handler) View(c *gin.Context) {
+	slug := c.Param("slug")
+
+	if !utils.IsValidSlug(slug) {
+		c.HTML(http.StatusBadRequest, "view.html", gin.H{
+			"Title":      "NCLIP - Error",
+			"Error":      "Invalid slug format",
+			"Version":    h.config.Version,
+			"BuildTime":  h.config.BuildTime,
+			"CommitHash": h.config.CommitHash,
+			"BaseURL":    h.getBaseURL(c),
+		})
+		return
+	}
+
+	paste, err := h.service.GetPaste(slug)
+	if err != nil {
+		log.Printf("[ERROR] View: %v", err)
+		c.HTML(http.StatusNotFound, "view.html", gin.H{
+			"Title":      "NCLIP - Not Found",
+			"Error":      "Paste not found or deleted",
+			"Version":    h.config.Version,
+			"BuildTime":  h.config.BuildTime,
+			"CommitHash": h.config.CommitHash,
+			"BaseURL":    h.getBaseURL(c),
+		})
+		return
+	}
+
+	// Increment read count
+	if err := h.service.IncrementReadCount(slug); err != nil {
+		// Log error but don't fail the request
+		fmt.Printf("Failed to increment read count for %s: %v\n", slug, err)
+	}
+
+	content, err := h.service.GetPasteContent(slug)
+	if err != nil {
+		log.Printf("[ERROR] View: content not found or deleted for slug %s: %v", slug, err)
+		c.HTML(http.StatusNotFound, "view.html", gin.H{
+			"Title":      "NCLIP - Not Found",
+			"Error":      "Paste content not found or deleted",
+			"Version":    h.config.Version,
+			"BuildTime":  h.config.BuildTime,
+			"CommitHash": h.config.CommitHash,
+			"BaseURL":    h.getBaseURL(c),
+		})
+		return
+	}
+
+	// If burn-after-read, delete and return 404 if accessed again
+	if paste.BurnAfterRead {
+		if err := h.service.DeletePaste(slug); err != nil {
+			fmt.Printf("Failed to delete burn-after-read paste %s: %v\n", slug, err)
+		}
+	}
+	if h.isCli(c) {
+		c.Header("Content-Type", paste.ContentType)
+		c.Header("Content-Length", fmt.Sprintf("%d", paste.Size))
+		c.Data(http.StatusOK, paste.ContentType, content)
+		return
+	}
+	if strings.Contains(c.Request.Header.Get("Accept"), "text/html") {
+		c.HTML(http.StatusOK, "view.html", gin.H{
+			"Title":      fmt.Sprintf("NCLIP - Paste %s", paste.ID),
+			"Paste":      paste,
+			"IsText":     utils.IsTextContent(paste.ContentType),
+			"Content":    string(content),
+			"Version":    h.config.Version,
+			"BuildTime":  h.config.BuildTime,
+			"CommitHash": h.config.CommitHash,
+			"BaseURL":    h.getBaseURL(c),
+		})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{
+		"id":              paste.ID,
+		"created_at":      paste.CreatedAt,
+		"expires_at":      paste.ExpiresAt,
+		"size":            paste.Size,
+		"content_type":    paste.ContentType,
+		"burn_after_read": paste.BurnAfterRead,
+		"content":         string(content),
+	})
+}
+
+// Raw handles raw content download via GET /raw/:slug
+func (h *Handler) Raw(c *gin.Context) {
+	slug := c.Param("slug")
+
+	paste, err := h.service.GetPaste(slug)
+	if err != nil {
+		log.Printf("[ERROR] Raw: %v", err)
+		c.JSON(http.StatusNotFound, gin.H{"error": "Paste not found or deleted"})
+		return
+	}
+
+	// Increment read count
+	if err := h.service.IncrementReadCount(slug); err != nil {
+		// Log error but don't fail the request
+		fmt.Printf("Failed to increment read count for %s: %v\n", slug, err)
+	}
+
+	content, err := h.service.GetPasteContent(slug)
+	if err != nil {
+		log.Printf("[ERROR] Raw: content not found or deleted for slug %s: %v", slug, err)
+		c.JSON(http.StatusNotFound, gin.H{"error": "Paste content not found or deleted"})
+		return
+	}
+
+	// If burn-after-read, delete and return 404 if accessed again
+	if paste.BurnAfterRead {
+		if err := h.service.DeletePaste(slug); err != nil {
+			fmt.Printf("Failed to delete burn-after-read paste %s: %v\n", slug, err)
+		}
+		// After deletion, return 404 and no content
+		c.JSON(http.StatusNotFound, gin.H{"error": "Paste not found or deleted (burn-after-read)"})
+		return
+	}
+	c.Header("Content-Type", paste.ContentType)
+	c.Header("Content-Length", fmt.Sprintf("%d", paste.Size))
+	ext := utils.ExtensionByMime(paste.ContentType)
+	filename := slug
+	if ext != "" {
+		filename = slug + ext
+	}
+	escaped := url.PathEscape(filename)
+	if utils.IsTextContent(paste.ContentType) {
+		c.Header("Content-Disposition", fmt.Sprintf("inline; filename=\"%s\"; filename*=UTF-8''%s", filename, escaped))
+	} else {
+		c.Header("Content-Disposition", fmt.Sprintf("attachment; filename=\"%s\"; filename*=UTF-8''%s", filename, escaped))
+	}
+	c.Data(http.StatusOK, paste.ContentType, content)
+}
+
+// getBaseURL returns the base URL for the application
+func (h *Handler) getBaseURL(c *gin.Context) string {
+	scheme := "http"
+	if h.isHTTPS(c) {
+		scheme = "https"
+	}
+	return fmt.Sprintf("%s://%s", scheme, c.Request.Host)
+}

--- a/handlers/upload/handler.go
+++ b/handlers/upload/handler.go
@@ -1,0 +1,209 @@
+package upload
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/johnwmail/nclip/config"
+	"github.com/johnwmail/nclip/internal/services"
+	"github.com/johnwmail/nclip/utils"
+)
+
+// Handler handles paste upload operations
+type Handler struct {
+	service *services.PasteService
+	config  *config.Config
+}
+
+// NewHandler creates a new upload handler
+func NewHandler(service *services.PasteService, config *config.Config) *Handler {
+	return &Handler{
+		service: service,
+		config:  config,
+	}
+}
+
+// parseTTL parses TTL from X-TTL header or uses default
+func (h *Handler) parseTTL(c *gin.Context) (time.Time, error) {
+	ttlStr := c.GetHeader("X-TTL")
+	if ttlStr != "" {
+		d, err := time.ParseDuration(ttlStr)
+		minTTL := time.Hour
+		maxTTL := 7 * 24 * time.Hour
+		if utils.IsDebugEnabled() {
+			log.Printf("[DEBUG] Parsed X-TTL duration: %v (raw: %s)", d, ttlStr)
+		}
+		if err != nil || d < minTTL || d > maxTTL {
+			return time.Time{}, fmt.Errorf("X-TTL must be between 1h and 7d")
+		}
+		return time.Now().Add(d), nil
+	}
+	return time.Now().Add(h.config.DefaultTTL), nil
+}
+
+// readUploadContent extracts content and filename from request
+func (h *Handler) readUploadContent(c *gin.Context) ([]byte, string, error) {
+	var content []byte
+	var filename string
+	var err error
+
+	if c.Request.Header.Get("Content-Type") != "" &&
+		strings.HasPrefix(c.Request.Header.Get("Content-Type"), "multipart/form-data") {
+		file, header, err := c.Request.FormFile("file")
+		if err != nil {
+			return nil, "", fmt.Errorf("no file provided")
+		}
+		defer func() { _ = file.Close() }()
+		filename = header.Filename
+		content, err = io.ReadAll(io.LimitReader(file, h.config.BufferSize))
+		if err != nil {
+			return nil, filename, fmt.Errorf("failed to read file")
+		}
+	} else {
+		content, err = io.ReadAll(io.LimitReader(c.Request.Body, h.config.BufferSize))
+		if err != nil {
+			return nil, "", fmt.Errorf("failed to read content")
+		}
+	}
+	if len(content) == 0 {
+		return nil, filename, fmt.Errorf("empty content")
+	}
+	return content, filename, nil
+}
+
+// storePasteAndRespond stores paste and responds to client
+func (h *Handler) storePasteAndRespond(c *gin.Context, req services.CreatePasteRequest) {
+	resp, err := h.service.CreatePaste(req)
+	if err != nil {
+		c.Header("Content-Type", "application/json; charset=utf-8")
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to create paste"})
+		return
+	}
+
+	pasteURL := h.generatePasteURL(c, resp.Slug)
+	resp.URL = pasteURL
+
+	// Always return JSON for web UI (browser)
+	if h.isCli(c) || c.Request.Header.Get("Accept") == "text/plain" {
+		c.String(http.StatusOK, pasteURL+"\n")
+		return
+	}
+	c.Header("Content-Type", "application/json; charset=utf-8")
+	c.JSON(http.StatusOK, gin.H{
+		"url":             resp.URL,
+		"slug":            resp.Slug,
+		"burn_after_read": req.BurnAfterRead,
+	})
+}
+
+// generatePasteURL generates the full URL for a paste
+func (h *Handler) generatePasteURL(c *gin.Context, slug string) string {
+	scheme := "http"
+	if h.isHTTPS(c) {
+		scheme = "https"
+	}
+	return fmt.Sprintf("%s://%s/%s", scheme, c.Request.Host, slug)
+}
+
+// isHTTPS detects if the request is over HTTPS
+func (h *Handler) isHTTPS(c *gin.Context) bool {
+	// Check X-Forwarded-Proto header (common with load balancers/proxies)
+	if c.GetHeader("X-Forwarded-Proto") == "https" {
+		return true
+	}
+
+	// AWS Lambda Function URLs may use different headers
+	if c.GetHeader("CloudFront-Forwarded-Proto") == "https" {
+		return true
+	}
+
+	// Check if the original URL scheme can be detected from request URL
+	if strings.HasPrefix(c.Request.Header.Get("Referer"), "https://") {
+		return true
+	}
+
+	return false
+}
+
+// isCli detects if the request is from CLI (curl, wget, Invoke-WebRequest, Invoke-RestMethod, etc.)
+func (h *Handler) isCli(c *gin.Context) bool {
+	userAgent := strings.ToLower(c.Request.Header.Get("User-Agent"))
+	if strings.Contains(userAgent, "curl") ||
+		strings.Contains(userAgent, "wget") ||
+		strings.Contains(userAgent, "powershell") {
+		return true
+	}
+	return false
+}
+
+// Upload handles paste upload via POST /
+func (h *Handler) Upload(c *gin.Context) {
+	content, filename, err := h.readUploadContent(c)
+	if err != nil {
+		log.Printf("[ERROR] %v", err)
+		c.Header("Content-Type", "application/json; charset=utf-8")
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	req := services.CreatePasteRequest{
+		Content:       content,
+		Filename:      filename,
+		BurnAfterRead: strings.HasSuffix(c.FullPath(), "/burn/"),
+	}
+
+	// Check for custom slug header
+	customSlug := c.GetHeader("X-Slug")
+	if customSlug != "" {
+		// Validate slug format
+		if !utils.IsValidSlug(customSlug) {
+			c.Header("Content-Type", "application/json; charset=utf-8")
+			c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid slug format"})
+			return
+		}
+		req.CustomSlug = customSlug
+	}
+
+	// Parse TTL
+	ttl, err := h.parseTTL(c)
+	if err != nil {
+		c.Header("Content-Type", "application/json; charset=utf-8")
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	req.TTL = time.Until(ttl)
+
+	h.storePasteAndRespond(c, req)
+}
+
+// UploadBurn handles paste upload with burn-after-read via POST /burn/
+func (h *Handler) UploadBurn(c *gin.Context) {
+	content, filename, err := h.readUploadContent(c)
+	if err != nil {
+		log.Printf("[ERROR] %v", err)
+		c.Header("Content-Type", "application/json; charset=utf-8")
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	req := services.CreatePasteRequest{
+		Content:       content,
+		Filename:      filename,
+		BurnAfterRead: true,
+	}
+
+	expiresAt, err := h.parseTTL(c)
+	if err != nil {
+		c.Header("Content-Type", "application/json; charset=utf-8")
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	req.TTL = time.Until(expiresAt)
+
+	h.storePasteAndRespond(c, req)
+}

--- a/internal/services/paste_service.go
+++ b/internal/services/paste_service.go
@@ -1,0 +1,170 @@
+package services
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/johnwmail/nclip/config"
+	"github.com/johnwmail/nclip/models"
+	"github.com/johnwmail/nclip/storage"
+	"github.com/johnwmail/nclip/utils"
+)
+
+// PasteService handles paste business logic
+type PasteService struct {
+	store  storage.PasteStore
+	config *config.Config
+}
+
+// NewPasteService creates a new paste service
+func NewPasteService(store storage.PasteStore, config *config.Config) *PasteService {
+	return &PasteService{
+		store:  store,
+		config: config,
+	}
+}
+
+// CreatePasteRequest represents a request to create a paste
+type CreatePasteRequest struct {
+	Content       []byte
+	Filename      string
+	CustomSlug    string
+	BurnAfterRead bool
+	TTL           time.Duration
+}
+
+// CreatePasteResponse represents the response from creating a paste
+type CreatePasteResponse struct {
+	Slug string
+	URL  string
+}
+
+// GenerateSlug generates a unique slug for a paste
+func (s *PasteService) GenerateSlug() (string, error) {
+	batchSize := 5
+	lengths := []int{5, 6, 7}
+	var slug string
+	for _, length := range lengths {
+		candidates, err := utils.GenerateSlugBatch(batchSize, length)
+		if err != nil {
+			return "", fmt.Errorf("failed to generate slug batch: %w", err)
+		}
+		for _, candidate := range candidates {
+			exists, err := s.store.Exists(candidate)
+			if err != nil {
+				continue // skip on error
+			}
+			if !exists {
+				slug = candidate
+				return slug, nil
+			}
+			// exists, check if expired
+			existing, err := s.store.Get(candidate)
+			if err != nil || existing == nil || existing.IsExpired() {
+				slug = candidate
+				return slug, nil
+			}
+		}
+	}
+	return "", fmt.Errorf("failed to generate unique slug after 3 batches")
+}
+
+// ValidateCustomSlug validates and checks if a custom slug is available
+func (s *PasteService) ValidateCustomSlug(slug string) error {
+	if !utils.IsValidSlug(slug) {
+		return fmt.Errorf("invalid slug format")
+	}
+
+	exists, err := s.store.Exists(slug)
+	if err != nil {
+		return fmt.Errorf("failed to check slug existence: %w", err)
+	}
+	if exists {
+		existing, err := s.store.Get(slug)
+		if err != nil {
+			return fmt.Errorf("failed to retrieve existing paste: %w", err)
+		}
+		if existing != nil && !existing.IsExpired() {
+			return fmt.Errorf("slug already exists")
+		}
+	}
+	return nil
+}
+
+// CreatePaste creates a new paste
+func (s *PasteService) CreatePaste(req CreatePasteRequest) (*CreatePasteResponse, error) {
+	var slug string
+	var err error
+
+	if req.CustomSlug != "" {
+		if err := s.ValidateCustomSlug(req.CustomSlug); err != nil {
+			return nil, err
+		}
+		slug = req.CustomSlug
+	} else {
+		slug, err = s.GenerateSlug()
+		if err != nil {
+			return nil, fmt.Errorf("failed to generate slug: %w", err)
+		}
+	}
+
+	expiresAt := time.Now().Add(req.TTL)
+
+	contentType := utils.DetectContentType(req.Filename, req.Content)
+	paste := &models.Paste{
+		ID:            slug,
+		CreatedAt:     time.Now(),
+		ExpiresAt:     &expiresAt,
+		Size:          int64(len(req.Content)),
+		ContentType:   contentType,
+		BurnAfterRead: req.BurnAfterRead,
+		ReadCount:     0,
+	}
+
+	if err := s.store.StoreContent(slug, req.Content); err != nil {
+		return nil, fmt.Errorf("failed to store content: %w", err)
+	}
+	if err := s.store.Store(paste); err != nil {
+		return nil, fmt.Errorf("failed to store metadata: %w", err)
+	}
+
+	return &CreatePasteResponse{
+		Slug: slug,
+		URL:  "", // Will be set by handler based on request context
+	}, nil
+}
+
+// GetPaste retrieves a paste by slug
+func (s *PasteService) GetPaste(slug string) (*models.Paste, error) {
+	paste, err := s.store.Get(slug)
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve paste: %w", err)
+	}
+	if paste == nil {
+		return nil, fmt.Errorf("paste not found")
+	}
+	if paste.IsExpired() {
+		return nil, fmt.Errorf("paste expired")
+	}
+
+	return paste, nil
+}
+
+// GetPasteContent retrieves paste content
+func (s *PasteService) GetPasteContent(slug string) ([]byte, error) {
+	content, err := s.store.GetContent(slug)
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve content: %w", err)
+	}
+	return content, nil
+}
+
+// IncrementReadCount increments the read count for a paste
+func (s *PasteService) IncrementReadCount(slug string) error {
+	return s.store.IncrementReadCount(slug)
+}
+
+// DeletePaste deletes a paste
+func (s *PasteService) DeletePaste(slug string) error {
+	return s.store.Delete(slug)
+}

--- a/main_test.go
+++ b/main_test.go
@@ -11,6 +11,9 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/johnwmail/nclip/config"
 	"github.com/johnwmail/nclip/handlers"
+	"github.com/johnwmail/nclip/handlers/retrieval"
+	"github.com/johnwmail/nclip/handlers/upload"
+	"github.com/johnwmail/nclip/internal/services"
 	"github.com/johnwmail/nclip/models"
 )
 
@@ -100,7 +103,9 @@ func setupTestRouter() (*gin.Engine, *MockStore) {
 
 	store := NewMockStore()
 
-	pasteHandler := handlers.NewPasteHandler(store, cfg)
+	pasteService := services.NewPasteService(store, cfg)
+	uploadHandler := upload.NewHandler(pasteService, cfg)
+	retrievalHandler := retrieval.NewHandler(pasteService, store, cfg)
 	metaHandler := handlers.NewMetaHandler(store)
 	systemHandler := handlers.NewSystemHandler()
 	webuiHandler := handlers.NewWebUIHandler(cfg)
@@ -111,10 +116,10 @@ func setupTestRouter() (*gin.Engine, *MockStore) {
 
 	// Routes (WebUI always enabled)
 	router.GET("/", webuiHandler.Index)
-	router.POST("/", pasteHandler.Upload)
-	router.POST("/burn/", pasteHandler.UploadBurn)
-	router.GET("/:slug", pasteHandler.View)
-	router.GET("/raw/:slug", pasteHandler.Raw)
+	router.POST("/", uploadHandler.Upload)
+	router.POST("/burn/", uploadHandler.UploadBurn)
+	router.GET("/:slug", retrievalHandler.View)
+	router.GET("/raw/:slug", retrievalHandler.Raw)
 	router.GET("/api/v1/meta/:slug", metaHandler.GetMetadata)
 	router.GET("/json/:slug", metaHandler.GetMetadata)
 	router.GET("/health", systemHandler.Health)


### PR DESCRIPTION
- Added upload handler for handling paste uploads via POST requests.
- Introduced methods for reading upload content, parsing TTL, and generating paste URLs.
- Created a new PasteService to manage paste-related business logic, including slug generation and validation.
- Updated main application to use the new upload and retrieval handlers.
- Refactored tests to accommodate the new handler structure and service integration.